### PR TITLE
fix(public-messages-lib): Reverted change to make transfer expiration optional in the Kafka message

### DIFF
--- a/packages/public-messages-lib/src/transfers-bc/requests.ts
+++ b/packages/public-messages-lib/src/transfers-bc/requests.ts
@@ -42,7 +42,7 @@ export type TransferPrepareRequestedEvtPayload = {
 	currencyCode: string;
 	ilpPacket: string;
 	condition: string;
-	expiration: number | null;
+	expiration: number;
 	extensionList: {
         extension: {
             key: string;
@@ -216,7 +216,7 @@ export type BulkTransferPrepareRequestedEvtPayload = {
         payeeIdType: string;
         transferType: string;
     }[];
-    expiration: number | null;
+    expiration: number;
     extensionList: {
         extension: {
             key: string;


### PR DESCRIPTION
Reverted change to make transfer expiration optional in the Kafka message